### PR TITLE
fix: eliminate warning for type inference to follow Elixir 1.19+

### DIFF
--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -602,23 +602,37 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
-  defp get_deps_types(ros2_message_type, types \\ MapSet.new([]), ros2_message_type_map) do
+  defp get_deps_types(ros2_message_type, ros2_message_type_map) do
+    ros2_message_type
+    |> collect_deps_types(%{}, ros2_message_type_map)
+    |> Map.keys()
+  end
+
+  defp collect_deps_types(ros2_message_type, seen, ros2_message_type_map) do
     get_fields(ros2_message_type, ros2_message_type_map)
-    |> Enum.reduce(types, fn field, acc ->
+    |> Enum.reduce(seen, fn field, acc ->
       [head | _] = field
 
       case head do
         {:msg_type, type} ->
-          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
+          put_and_collect_deps_types(type, acc, ros2_message_type_map)
 
         {:msg_type_array, type} ->
           %{type: type} = get_array_type(type)
-          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
+          put_and_collect_deps_types(type, acc, ros2_message_type_map)
 
         _ ->
           acc
       end
     end)
+  end
+
+  defp put_and_collect_deps_types(type, seen, ros2_message_type_map) do
+    if Map.has_key?(seen, type) do
+      seen
+    else
+      collect_deps_types(type, Map.put(seen, type, true), ros2_message_type_map)
+    end
   end
 
   defp get_fields(ros2_message_type, ros2_message_type_map) do

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -67,7 +67,7 @@ defmodule Rclex.Generators.MsgC do
     |> format
   end
 
-  def enif_get({:msg_type, ros2_message_type}, acc, ros2_message_type_map) do
+  def enif_get({:msg_type, ros2_message_type}, %Acc{} = acc, ros2_message_type_map) do
     fields = get_fields(ros2_message_type, ros2_message_type_map)
 
     Enum.with_index(fields)
@@ -104,7 +104,7 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
-  def enif_get({:builtin_type, type}, acc, _ros2_message_type_map) do
+  def enif_get({:builtin_type, type}, %Acc{} = acc, _ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     term = Enum.join(acc.terms, "_")
@@ -112,14 +112,14 @@ defmodule Rclex.Generators.MsgC do
     enif_get_builtin(type, var, mbr, term)
   end
 
-  def enif_get({:msg_type_array, type}, acc, ros2_message_type_map) do
+  def enif_get({:msg_type_array, type}, %Acc{} = acc, ros2_message_type_map) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         enif_get({:msg_type_array_unbounded, type}, acc, ros2_message_type_map)
     end
   end
 
-  def enif_get({:msg_type_array_unbounded, type}, acc, ros2_message_type_map) do
+  def enif_get({:msg_type_array_unbounded, type}, %Acc{} = acc, ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     term = Enum.join(acc.terms, "_")
@@ -159,7 +159,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  def enif_get({:builtin_type_array, type}, acc, ros2_message_type_map) do
+  def enif_get({:builtin_type_array, type}, %Acc{} = acc, ros2_message_type_map) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         enif_get({:builtin_type_array_unbounded, type}, acc, ros2_message_type_map)
@@ -169,7 +169,11 @@ defmodule Rclex.Generators.MsgC do
     end
   end
 
-  def enif_get({:builtin_type_array_unbounded, "uint8" = type}, acc, _ros2_message_type_map) do
+  def enif_get(
+        {:builtin_type_array_unbounded, "uint8" = type},
+        %Acc{} = acc,
+        _ros2_message_type_map
+      ) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     term = Enum.join(acc.terms, "_")
@@ -190,7 +194,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  def enif_get({:builtin_type_array_unbounded, type}, acc, ros2_message_type_map) do
+  def enif_get({:builtin_type_array_unbounded, type}, %Acc{} = acc, ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     term = Enum.join(acc.terms, "_")
@@ -230,7 +234,11 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  def enif_get({:builtin_type_array_static, "uint8" = _type, size}, acc, _ros2_message_type_map) do
+  def enif_get(
+        {:builtin_type_array_static, "uint8" = _type, size},
+        %Acc{} = acc,
+        _ros2_message_type_map
+      ) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     term = Enum.join(acc.terms, "_")
@@ -243,7 +251,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  def enif_get({:builtin_type_array_static, type, size}, acc, ros2_message_type_map) do
+  def enif_get({:builtin_type_array_static, type, size}, %Acc{} = acc, ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     term = Enum.join(acc.terms, "_")
 
@@ -364,23 +372,23 @@ defmodule Rclex.Generators.MsgC do
     |> format()
   end
 
-  def build_get_fun_fragments(acc, lhs \\ "return", ros2_message_type_map) do
+  def build_get_fun_fragments(%Acc{} = acc, lhs \\ "return", ros2_message_type_map) do
     {binary, accs} = enif_make(acc.type, acc, ros2_message_type_map)
 
     rhs = binary |> String.replace_suffix("\n", "")
 
     array_accs =
-      Enum.filter(accs, fn acc ->
+      Enum.filter(accs, fn %Acc{} = acc ->
         {type_atom, _} = acc.type
         type_atom in [:msg_type_array, :builtin_type_array]
       end)
 
-    Enum.map_join(array_accs, fn acc ->
+    Enum.map_join(array_accs, fn %Acc{} = acc ->
       build_get_fun_fragments_array(acc.type, acc, ros2_message_type_map)
     end) <> "#{lhs} #{rhs};"
   end
 
-  def build_get_fun_fragments_array({:msg_type_array, type}, acc, ros2_message_type_map) do
+  def build_get_fun_fragments_array({:msg_type_array, type}, %Acc{} = acc, ros2_message_type_map) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         array_for(
@@ -391,7 +399,11 @@ defmodule Rclex.Generators.MsgC do
     end
   end
 
-  def build_get_fun_fragments_array({:builtin_type_array, type}, acc, ros2_message_type_map) do
+  def build_get_fun_fragments_array(
+        {:builtin_type_array, type},
+        %Acc{} = acc,
+        ros2_message_type_map
+      ) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         array_for(
@@ -409,7 +421,7 @@ defmodule Rclex.Generators.MsgC do
     end
   end
 
-  defp array_for({:unbounded, "uint8" = _type}, acc, _ros2_message_type_map) do
+  defp array_for({:unbounded, "uint8" = _type}, %Acc{} = acc, _ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
 
@@ -422,7 +434,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  defp array_for({:unbounded, _type}, acc, ros2_message_type_map) do
+  defp array_for({:unbounded, _type}, %Acc{} = acc, ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
 
@@ -445,7 +457,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  defp array_for({:static, "uint8" = _type, size}, acc, _ros2_message_type_map) do
+  defp array_for({:static, "uint8" = _type, size}, %Acc{} = acc, _ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
 
@@ -458,7 +470,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  defp array_for({:static, _type, size}, acc, ros2_message_type_map) do
+  defp array_for({:static, _type, size}, %Acc{} = acc, ros2_message_type_map) do
     var = Enum.join(acc.vars, "_")
 
     mbrs = List.pop_at(acc.mbrs, -1) |> then(fn {mbr, mbrs} -> mbrs ++ ["#{mbr}[#{var}_i]"] end)
@@ -480,7 +492,7 @@ defmodule Rclex.Generators.MsgC do
     """
   end
 
-  def enif_make({:msg_type, ros2_message_type}, acc, ros2_message_type_map) do
+  def enif_make({:msg_type, ros2_message_type}, %Acc{} = acc, ros2_message_type_map) do
     fields = get_fields(ros2_message_type, ros2_message_type_map)
 
     {binaries, accs} =
@@ -511,7 +523,7 @@ defmodule Rclex.Generators.MsgC do
     {binary, accs}
   end
 
-  def enif_make({:msg_type_array, type}, acc, _ros2_message_type_map) do
+  def enif_make({:msg_type_array, type}, %Acc{} = acc, _ros2_message_type_map) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         {enif_make_array({:unbounded, type}, acc), [acc]}
@@ -521,7 +533,7 @@ defmodule Rclex.Generators.MsgC do
     end
   end
 
-  def enif_make({:builtin_type_array, type}, acc, _ros2_message_type_map) do
+  def enif_make({:builtin_type_array, type}, %Acc{} = acc, _ros2_message_type_map) do
     case get_array_type(type) do
       %{type: type, kind: :unbounded_dynamic} ->
         {enif_make_array({:unbounded, type}, acc), [acc]}
@@ -531,28 +543,28 @@ defmodule Rclex.Generators.MsgC do
     end
   end
 
-  def enif_make({:builtin_type, type}, acc, _ros2_message_type_map) do
+  def enif_make({:builtin_type, type}, %Acc{} = acc, _ros2_message_type_map) do
     mbr = Enum.join(acc.mbrs, ".")
     {enif_make_builtin(type, mbr), [acc]}
   end
 
-  defp enif_make_array({:unbounded, "uint8" = _type}, acc) do
+  defp enif_make_array({:unbounded, "uint8" = _type}, %Acc{} = acc) do
     var = Enum.join(acc.vars, "_")
     "enif_make_binary(env, &#{var}_binary)"
   end
 
-  defp enif_make_array({:unbounded, _type}, acc) do
+  defp enif_make_array({:unbounded, _type}, %Acc{} = acc) do
     var = Enum.join(acc.vars, "_")
     mbr = Enum.join(acc.mbrs, ".")
     "enif_make_list_from_array(env, #{var}, message_p->#{mbr}.size)"
   end
 
-  defp enif_make_array({:static, "uint8" = _type, _size}, acc) do
+  defp enif_make_array({:static, "uint8" = _type, _size}, %Acc{} = acc) do
     var = Enum.join(acc.vars, "_")
     "enif_make_binary(env, &#{var}_binary)"
   end
 
-  defp enif_make_array({:static, _type, size}, acc) do
+  defp enif_make_array({:static, _type, size}, %Acc{} = acc) do
     var = Enum.join(acc.vars, "_")
     "enif_make_list_from_array(env, #{var}, #{size})"
   end

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -601,18 +601,22 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
-  defp get_deps_types(ros2_message_type, types \\ MapSet.new([]), ros2_message_type_map) do
+  defp get_deps_types(ros2_message_type, ros2_message_type_map) do
+    get_deps_types(ros2_message_type, [], ros2_message_type_map)
+  end
+
+  defp get_deps_types(ros2_message_type, types, ros2_message_type_map) do
     get_fields(ros2_message_type, ros2_message_type_map)
     |> Enum.reduce(types, fn field, acc ->
       [head | _] = field
 
       case head do
         {:msg_type, type} ->
-          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
+          get_deps_types(type, Enum.uniq([type | acc]), ros2_message_type_map)
 
         {:msg_type_array, type} ->
           %{type: type} = get_array_type(type)
-          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
+          get_deps_types(type, Enum.uniq([type | acc]), ros2_message_type_map)
 
         _ ->
           acc

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -30,8 +30,7 @@ defmodule Rclex.Generators.MsgC do
 
   @spec to_deps_header_prefix_list(String.t(), map()) :: list()
   def to_deps_header_prefix_list(ros2_message_type, ros2_message_type_map) do
-    get_deps_types(ros2_message_type, ros2_message_type_map)
-    |> Enum.sort()
+    get_deps_types(ros2_message_type, MapSet.new(), ros2_message_type_map)
     |> Enum.map(fn ros2_message_type ->
       [interfaces, "msg", type] = ros2_message_type |> String.split("/")
       [interfaces, "msg", "detail", Util.to_down_snake(type)] |> Path.join()
@@ -619,37 +618,26 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
-  defp get_deps_types(ros2_message_type, ros2_message_type_map) do
-    ros2_message_type
-    |> collect_deps_types(%{}, ros2_message_type_map)
-    |> Map.keys()
-  end
-
-  defp collect_deps_types(ros2_message_type, seen, ros2_message_type_map) do
+  @dialyzer {:nowarn_function, get_deps_types: 3}
+  @spec get_deps_types(String.t(), MapSet.t(String.t()), map()) :: MapSet.t(String.t())
+  defp get_deps_types(ros2_message_type, types, ros2_message_type_map)
+       when is_struct(types, MapSet) do
     get_fields(ros2_message_type, ros2_message_type_map)
-    |> Enum.reduce(seen, fn field, acc ->
+    |> Enum.reduce(types, fn field, %MapSet{} = acc ->
       [head | _] = field
 
       case head do
         {:msg_type, type} ->
-          put_and_collect_deps_types(type, acc, ros2_message_type_map)
+          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
 
         {:msg_type_array, type} ->
           %{type: type} = get_array_type(type)
-          put_and_collect_deps_types(type, acc, ros2_message_type_map)
+          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
 
         _ ->
           acc
       end
     end)
-  end
-
-  defp put_and_collect_deps_types(type, seen, ros2_message_type_map) do
-    if Map.has_key?(seen, type) do
-      seen
-    else
-      collect_deps_types(type, Map.put(seen, type, true), ros2_message_type_map)
-    end
   end
 
   defp get_fields(ros2_message_type, ros2_message_type_map) do

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -618,6 +618,7 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
+  # REMOVE THE LINE BELOW ONCE https://github.com/rclex/rclex/issues/402 IS RESOLVED
   @dialyzer {:nowarn_function, get_deps_types: 3}
   @spec get_deps_types(String.t(), MapSet.t(String.t()), map()) :: MapSet.t(String.t())
   defp get_deps_types(ros2_message_type, types, ros2_message_type_map)

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -4,6 +4,7 @@ defmodule Rclex.Generators.MsgC do
   alias Rclex.Generators.Util
   alias Rclex.Parsers.TypeParser
 
+  @spec generate(String.t(), map()) :: String.t()
   def generate(type, ros2_message_type_map) do
     set_fun_fragments = set_fun_fragments(type, ros2_message_type_map)
     is_empty_type? = set_fun_fragments == ""
@@ -21,11 +22,13 @@ defmodule Rclex.Generators.MsgC do
     )
   end
 
+  @spec to_header_name(String.t()) :: String.t()
   def to_header_name(ros2_message_type) do
     [_interfaces, "msg", type] = ros2_message_type |> String.split("/")
     Util.to_down_snake(type)
   end
 
+  @spec to_deps_header_prefix_list(String.t(), map()) :: list()
   def to_deps_header_prefix_list(ros2_message_type, ros2_message_type_map) do
     get_deps_types(ros2_message_type, ros2_message_type_map)
     |> Enum.sort()
@@ -40,6 +43,7 @@ defmodule Rclex.Generators.MsgC do
     [interfaces, "msg", "detail", Util.to_down_snake(type)] |> Path.join()
   end
 
+  @spec rosidl_get_msg_type_support(String.t()) :: String.t()
   def rosidl_get_msg_type_support(ros2_message_type) do
     [interfaces, "msg", type] = ros2_message_type |> String.split("/")
     "ROSIDL_GET_MSG_TYPE_SUPPORT(#{interfaces}, msg, #{type})"
@@ -52,6 +56,7 @@ defmodule Rclex.Generators.MsgC do
   iex> Rclex.Generators.MsgC.to_c_type("std_msgs/msg/UInt32MultiArray")
   "std_msgs__msg__UInt32MultiArray"
   """
+  @spec to_c_type(String.t()) :: String.t()
   def to_c_type(ros2_message_type) do
     [interfaces, "msg", type] = ros2_message_type |> String.split("/")
     [interfaces, "_msg_", type] |> Enum.join("_")

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -28,6 +28,7 @@ defmodule Rclex.Generators.MsgC do
 
   def to_deps_header_prefix_list(ros2_message_type, ros2_message_type_map) do
     get_deps_types(ros2_message_type, ros2_message_type_map)
+    |> Enum.sort()
     |> Enum.map(fn ros2_message_type ->
       [interfaces, "msg", type] = ros2_message_type |> String.split("/")
       [interfaces, "msg", "detail", Util.to_down_snake(type)] |> Path.join()

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -71,7 +71,7 @@ defmodule Rclex.Generators.MsgC do
 
     Enum.with_index(fields)
     |> Enum.map_join("\n", fn {[_, name | _] = field, index} ->
-      acc = %Acc{
+      acc = %{
         acc
         | vars: acc.vars ++ [name],
           mbrs: acc.mbrs ++ [name],
@@ -127,7 +127,7 @@ defmodule Rclex.Generators.MsgC do
 
     binary =
       (fn ->
-         acc = %Acc{acc | vars: acc.vars ++ ["i"], mbrs: acc.mbrs ++ ["data[#{var}_i]"]}
+         acc = %{acc | vars: acc.vars ++ ["i"], mbrs: acc.mbrs ++ ["data[#{var}_i]"]}
          enif_get({:msg_type, type}, acc, ros2_message_type_map)
        end).()
       |> format()
@@ -202,7 +202,7 @@ defmodule Rclex.Generators.MsgC do
 
     binary =
       (fn ->
-         acc = %Acc{acc | vars: vars, mbrs: mbrs, terms: terms}
+         acc = %{acc | vars: vars, mbrs: mbrs, terms: terms}
          enif_get({:builtin_type, type}, acc, ros2_message_type_map)
        end).()
       |> format()
@@ -252,7 +252,7 @@ defmodule Rclex.Generators.MsgC do
 
     binary =
       (fn ->
-         acc = %Acc{acc | vars: vars, mbrs: mbrs, terms: terms}
+         acc = %{acc | vars: vars, mbrs: mbrs, terms: terms}
          enif_get({:builtin_type, type}, acc, ros2_message_type_map)
        end).()
       |> format()
@@ -384,7 +384,7 @@ defmodule Rclex.Generators.MsgC do
       %{type: type, kind: :unbounded_dynamic} ->
         array_for(
           {:unbounded, type},
-          %Acc{acc | type: {:msg_type, type}},
+          %{acc | type: {:msg_type, type}},
           ros2_message_type_map
         )
     end
@@ -395,14 +395,14 @@ defmodule Rclex.Generators.MsgC do
       %{type: type, kind: :unbounded_dynamic} ->
         array_for(
           {:unbounded, type},
-          %Acc{acc | type: {:builtin_type, type}},
+          %{acc | type: {:builtin_type, type}},
           ros2_message_type_map
         )
 
       %{type: type, kind: :static, size: size} ->
         array_for(
           {:static, type, size},
-          %Acc{acc | type: {:builtin_type, type}},
+          %{acc | type: {:builtin_type, type}},
           ros2_message_type_map
         )
     end
@@ -427,7 +427,7 @@ defmodule Rclex.Generators.MsgC do
 
     mbrs = acc.mbrs ++ ["data[#{var}_i]"]
 
-    acc = %Acc{acc | mbrs: mbrs}
+    acc = %{acc | mbrs: mbrs}
 
     binary =
       build_get_fun_fragments(acc, "#{var}[#{var}_i] =", ros2_message_type_map)
@@ -462,7 +462,7 @@ defmodule Rclex.Generators.MsgC do
 
     mbrs = List.pop_at(acc.mbrs, -1) |> then(fn {mbr, mbrs} -> mbrs ++ ["#{mbr}[#{var}_i]"] end)
 
-    acc = %Acc{acc | mbrs: mbrs}
+    acc = %{acc | mbrs: mbrs}
 
     binary =
       build_get_fun_fragments(acc, "#{var}[#{var}_i] =", ros2_message_type_map)
@@ -484,7 +484,7 @@ defmodule Rclex.Generators.MsgC do
 
     {binaries, accs} =
       Enum.map_reduce(fields, [], fn [_, name | _] = field, accs ->
-        acc = %Acc{acc | vars: acc.vars ++ [name], mbrs: acc.mbrs ++ [name], type: hd(field)}
+        acc = %{acc | vars: acc.vars ++ [name], mbrs: acc.mbrs ++ [name], type: hd(field)}
         {binary, accs_} = enif_make(acc.type, acc, ros2_message_type_map)
         {binary, accs ++ accs_}
       end)

--- a/lib/rclex/generators/msg_c.ex
+++ b/lib/rclex/generators/msg_c.ex
@@ -602,22 +602,18 @@ defmodule Rclex.Generators.MsgC do
     end)
   end
 
-  defp get_deps_types(ros2_message_type, ros2_message_type_map) do
-    get_deps_types(ros2_message_type, [], ros2_message_type_map)
-  end
-
-  defp get_deps_types(ros2_message_type, types, ros2_message_type_map) do
+  defp get_deps_types(ros2_message_type, types \\ MapSet.new([]), ros2_message_type_map) do
     get_fields(ros2_message_type, ros2_message_type_map)
     |> Enum.reduce(types, fn field, acc ->
       [head | _] = field
 
       case head do
         {:msg_type, type} ->
-          get_deps_types(type, Enum.uniq([type | acc]), ros2_message_type_map)
+          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
 
         {:msg_type_array, type} ->
           %{type: type} = get_array_type(type)
-          get_deps_types(type, Enum.uniq([type | acc]), ros2_message_type_map)
+          get_deps_types(type, MapSet.put(acc, type), ros2_message_type_map)
 
         _ ->
           acc

--- a/lib/rclex/nodes_supervisor.ex
+++ b/lib/rclex/nodes_supervisor.ex
@@ -23,7 +23,6 @@ defmodule Rclex.NodesSupervisor do
 
     case GenServer.whereis(name) do
       nil -> {:error, :not_found}
-      {_atom, _node} -> raise("should not happen")
       pid -> DynamicSupervisor.terminate_child(name(), pid)
     end
   end

--- a/lib/rclex/publisher.ex
+++ b/lib/rclex/publisher.ex
@@ -23,7 +23,6 @@ defmodule Rclex.Publisher do
   def publish(%message_type{} = message, topic_name, name, namespace \\ "/") do
     case GenServer.whereis(name(message_type, topic_name, name, namespace)) do
       nil -> {:error, :not_found}
-      {_atom, _node} -> raise("should not happen")
       pid -> GenServer.call(pid, {:publish, message})
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule Rclex.MixProject do
       make_clean: ["clean"],
       compilers: [:elixir_make] ++ Mix.compilers(),
       aliases: [format: [&format_c/1, "format"], iwyu: [&iwyu/1]],
+      test_ignore_filters: [&String.starts_with?(&1, "test/expected_files/")],
       test_coverage: test_coverage(),
       dialyzer: dialyzer(),
       # for hex

--- a/test/rclex/nif_benchmark_test.exs
+++ b/test/rclex/nif_benchmark_test.exs
@@ -1,8 +1,6 @@
 defmodule Rclex.NifBenchmarkTest do
   use ExUnit.Case
 
-  require Logger
-
   import ExUnit.CaptureLog
 
   alias Rclex.Nif

--- a/test/rclex/nif_test.exs
+++ b/test/rclex/nif_test.exs
@@ -55,7 +55,7 @@ defmodule Rclex.NifTest do
         ex ->
           %ErlangError{original: charlist, reason: nil} = ex
 
-          assert "#{charlist}" =~
+          assert inspect(charlist) =~
                    "node name must not contain characters other than alphanumerics or '_'"
       end
     end
@@ -67,7 +67,7 @@ defmodule Rclex.NifTest do
         ex ->
           %ErlangError{original: charlist, reason: nil} = ex
 
-          assert "#{charlist}" =~ "namespace must be absolute, it must lead with a '/'"
+          assert inspect(charlist) =~ "namespace must be absolute, it must lead with a '/'"
       end
     end
   end


### PR DESCRIPTION
## 概要
Elixir 1.19+ / 1.20 で顕在化した型推論・警告まわりの問題を解消する修正です．
#400 https://github.com/rclex/rclex/pull/400/changes/08c8476040a2cfcec73fc70f6c89dceb306e9007 では全バージョンのCIで `mix test --warning-as-errors --cover` としており，これでも落ちない状態にすることを目指しました．

- MsgC 生成処理で、構造体更新や依存収集ロジックが新しい型推論で warning 対象になっていた
- GenServer.whereis の戻り値に対して到達不能節があり、Elixir 1.20 で warning が出る
- test 配下の expected_files が Mix test ローダー警告対象になる
- 一部テストコードに未使用 require が残っていた
- Dialyzer 実行時に，MapSet を引数に持つ warning 表示経路で Dialyxir 側の既知問題に当たるケースがあった

## 変更内容
1. MsgC 生成ロジックの warning 対応
- msg_c.ex
  - 構造体更新の書き方を見直し
  - 依存収集の順序を安定化
  - ~~依存収集 accumulator を MapSet 依存から plain map ベースへ変更し、Dialyzer 実行時の問題回避と計算量悪化の抑制を両立~~

2. 到達不能分岐の削除
- publisher.ex
  - nodes_supervisor.ex
  - GenServer.whereis の戻り値に対する不要分岐を削除

3. テスト警告の解消
- mix.exs
  - test_ignore_filters を追加し、test/expected_files 配下をテストローダー警告対象から除外
- nif_benchmark_test.exs
  - 未使用 require を削除
- nif_test.exs
  - エラーメッセージ検証の書き方を warning 回避形へ調整

## 検証
- humble-ex1.20.0-otp29.0.1 で mix test 実行し通過
- msg_c_test.exs のゴールデン比較が通過
- latest 環境で mix dialyzer 通過を確認

## 補足
- 本PRには、Dialyzer 実行安定化のための回避的実装を含みます
- upstream 側の状況が改善した場合は、実装の簡素化を再検討します #402 
- 参照コミット
  - 7aed2cf5653204ee08b38a7567904742105929f6
  - ede8070
