### PR TITLE
Release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v0.13.1 on 24 Jun 2026
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.13.0...v0.13.1
+
+## What's Changed
+
+* New features:
+  * Add jazzy support to `mix rclex.prep.ros2` by @pojiro in https://github.com/rclex/rclex/pull/391
+  * feat: change `latest` to ROS 2 Jazzy Jalisco by @takasehideki in https://github.com/rclex/rclex/pull/407
+* Code Improvements/Fixes: none
+* Bumps: none
+* Note in this release:
+  * Jazzy is also now available on Nerves!
+  * Recommended ROS 2 distribution is switched to Jazzy!
+
 ## v0.13.0 on 11 Jun 2026
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.12.0...v0.13.0

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.0"},
+      {:rclex, "~> 0.13.1"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -95,7 +95,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.0"},
+      {:rclex, "~> 0.13.1"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -68,7 +68,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.0"},
+      {:rclex, "~> 0.13.1"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Rclex.MixProject do
   """
 
   @app :rclex
-  @version "0.13.0"
+  @version "0.13.1"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
**Full Changelog**: https://github.com/rclex/rclex/compare/v0.13.0...v0.13.1

* New features:
  * Add jazzy support to `mix rclex.prep.ros2` by @pojiro in https://github.com/rclex/rclex/pull/391
  * feat: change `latest` to ROS 2 Jazzy Jalisco by @takasehideki in https://github.com/rclex/rclex/pull/407
* Code Improvements/Fixes: none
* Bumps: none
* Note in this release:
  * Jazzy is also now available on Nerves!
  * Recommended ROS 2 distribution is switched to Jazzy!