### PR TITLE
Release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # CHANGELOG
 
+## v0.13.2 on 17 Aug 2026
+
+**Full Changelog**: https://github.com/rclex/rclex/compare/v0.13.1...v0.13.2
+
+* New features:
+  * Add `--dockerfile` option concept to mix rclex.prep.ros2 by @pojiro in https://github.com/rclex/rclex/pull/409
+* Code Improvements/Fixes: none
+* Bumps:
+  * chore(deps-dev): bump git_hooks from 0.8.1 to 0.9.0 by @dependabot[bot] in https://github.com/rclex/rclex/pull/411
+* Note in this release: none
+
 ## v0.13.1 on 24 Jun 2026
 
 **Full Changelog**: https://github.com/rclex/rclex/compare/v0.13.0...v0.13.1
-
-## What's Changed
 
 * New features:
   * Add jazzy support to `mix rclex.prep.ros2` by @pojiro in https://github.com/rclex/rclex/pull/391

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.1"},
+      {:rclex, "~> 0.13.2"},
       ...
     ]
   end

--- a/README_ja.md
+++ b/README_ja.md
@@ -101,7 +101,7 @@ cd rclex_usage
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.1"},
+      {:rclex, "~> 0.13.2"},
       ...
     ]
   end

--- a/USE_ON_NERVES.md
+++ b/USE_ON_NERVES.md
@@ -68,7 +68,7 @@ by adding `rclex` to your list of dependencies in `mix.exs`:
   defp deps do
     [
       ...
-      {:rclex, "~> 0.13.1"},
+      {:rclex, "~> 0.13.2"},
       ...
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Rclex.MixProject do
   """
 
   @app :rclex
-  @version "0.13.1"
+  @version "0.13.2"
   @source_url "https://github.com/rclex/rclex"
 
   def project do


### PR DESCRIPTION
**Full Changelog**: https://github.com/rclex/rclex/compare/v0.13.1...v0.13.2

* New features:
  * Add `--dockerfile` option concept to mix rclex.prep.ros2 by @pojiro in https://github.com/rclex/rclex/pull/409
* Code Improvements/Fixes: none
* Bumps:
  * chore(deps-dev): bump git_hooks from 0.8.1 to 0.9.0 by @dependabot[bot] in https://github.com/rclex/rclex/pull/411
* Note in this release: none